### PR TITLE
fix: remove repetições na listagem de turmas

### DIFF
--- a/src/pages/people/[person].astro
+++ b/src/pages/people/[person].astro
@@ -40,9 +40,13 @@ export async function getStaticPaths() {
 
 const { person, projects } = Astro.props;
 
-const subjects = projects
-  .filter((projects) => isSubjectProject(projects))
-  .map((project) => getSubjectByProject(project));
+const subjects = [
+  ...new Set(
+    projects
+      .filter((project) => isSubjectProject(project))
+      .map((project) => getSubjectByProject(project))
+  ),
+];
 ---
 
 


### PR DESCRIPTION
### Problema:
A listagem de turmas apresentava repetições quando mais de um projeto estava associado à mesma turma.

### Solução:
Utilização de `Set` para garantir que as turmas sejam exibidas apenas uma vez.

### Impacto:
Corrige a duplicação de tags de turmas na interface.